### PR TITLE
testnet parameter was passed wrongly to `render_wif`

### DIFF
--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -542,7 +542,7 @@ def dump_key_info(slot_num, privkey, wif=None, is_testnet=False):
 
     addr = render_address(privkey, is_testnet)
 
-    wif = wif or render_wif(privkey, is_testnet)
+    wif = wif or render_wif(privkey, testnet=is_testnet)
 
     click.echo(f"Slot #{slot_num}:\n\n{addr}\n\n{wif}")
 


### PR DESCRIPTION
is_testnet was passed as bip178 which caused that dumped wif from 'unseal' command ignored network parameter

as you can see in attached image 'unseal' cmd produced different wif than 'wif' cmd executed later on the same slot 

![Screenshot from 2022-03-29 19-13-46](https://user-images.githubusercontent.com/25349625/160669486-f5e31ca0-0a23-4637-9234-2a4f2e5a17a2.png)
