### PR TITLE
handle ValueError in `set_derivation`

### DIFF
--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -37,7 +37,7 @@ sys.excepthook=my_hook
 
 def fail(msg):
     # show message and stop
-    click.echo("FAILURE: " + msg, err=True)
+    click.echo(f"FAILURE: {msg}", err=True)
     sys.exit(1)
 
 def get_card(only_satscard=False, only_tapsigner=False):

--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -472,7 +472,7 @@ def set_derivation(path, cvc, skip_checks):
     try:
         card.set_derivation(path, cvc)
     except ValueError as err:
-        fail(err)
+        fail(str(err))
 
     xp = card.get_xpub(cvc)
 

--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -37,7 +37,7 @@ sys.excepthook=my_hook
 
 def fail(msg):
     # show message and stop
-    click.echo(msg)
+    click.echo("FAILURE: " + msg, err=True)
     sys.exit(1)
 
 def get_card(only_satscard=False, only_tapsigner=False):
@@ -469,7 +469,10 @@ def set_derivation(path, cvc, skip_checks):
     card = get_card(only_tapsigner=True)
 
     cvc = cleanup_cvc(card, cvc)
-    child_depth, cc, pub = card.set_derivation(path, cvc)
+    try:
+        card.set_derivation(path, cvc)
+    except ValueError as err:
+        fail(err)
 
     xp = card.get_xpub(cvc)
 


### PR DESCRIPTION
![Screenshot from 2022-03-30 19-18-03](https://user-images.githubusercontent.com/25349625/160897718-d6782023-c43a-4c5a-b5c5-0995e60c8896.png)

IMO unnecessary exception dumped on users. 

`fail` should print to stderr and have prepended it with FAILURE so it is clear that something is not good
