### PR TITLE
Core cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,97 @@ bc1qu4vsv2jqgl0y30ehrs4d0dg23xazpgnxdwuqum
 Enter spending code (6 digits):
 p2wpkh:L16cgmhZJWD7fq3eDi3gL7Yko6WYixxZi4f5T3XxxDCF2HnZdHJa
 
+% cktap core -p  # this will dump all used slots as watch only (no CVC provided)
+Warning: Without the code, can only watch addresses from this card.
+
+importdescriptors '[
+  {
+    "desc": "addr(tb1qdu05evh9kw0w482lfl2ktxm6ylp060kmqpe5js)#n0s7nyz0",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_0"
+  },
+  {
+    "desc": "addr(tb1qf0p2rky4d9knwdxz4pqnxv68j3cr0dyp6yp3h0)#6de55q4e",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_1"
+  },
+  {
+    "desc": "addr(tb1q6tjz70fyh4c3l2muk4fexfvpuq39p3657sxquy)#etka7xuj",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_2"
+  },
+  {
+    "desc": "addr(tb1q7wz86pgrswqzsnc4u7qt0zu7zjrqgjqr5q7lh5)#9c8u3mjt",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_3"
+  }
+]'
+
+% cktap core 123456 -p  # this will dump only unsealed slots (CVC provided)
+importdescriptors '[
+  {
+    "desc": "wpkh(cU7CGBhwnMdLDbqBaXm3xE22KFyaA5s3YDBis88LyuPLnmfpDFFU)#2kyyxsrc",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_0"
+  },
+  {
+    "desc": "wpkh(cTUoyVV4m9FZJXW9CBMRKbKa1UQ4BiUy49i5v7Q5KJkZ9dv1h7Kw)#cf3asx2t",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_1"
+  },
+  {
+    "desc": "wpkh(cMvFqzkcfibpt4WJuuHWq6SpKLZmxWFQCD5hxtSGdRzdcbVKafQz)#7vp0t4rx",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_2"
+  }
+]'
+
+% cktap core --sealed-only -p  # dump only sealed slots as watch only (do not provide CVC)
+Warning: Without the code, can only watch addresses from this card.
+
+importdescriptors '[
+  {
+    "desc": "addr(tb1q7wz86pgrswqzsnc4u7qt0zu7zjrqgjqr5q7lh5)#9c8u3mjt",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_3"
+  }
+]'
+
+% cktap core 123456 -s 0 -p  # dump only slot 0 (with CVC with private key)
+importdescriptors '[
+  {
+    "desc": "wpkh(cU7CGBhwnMdLDbqBaXm3xE22KFyaA5s3YDBis88LyuPLnmfpDFFU)#2kyyxsrc",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_0"
+  }
+]'
+
+% cktap core -s 0 -s 2 -p  # dump only slot 0 and slot 2 watch only (no CVC provided)
+Warning: Without the code, can only watch addresses from this card.
+
+importdescriptors '[
+  {
+    "desc": "addr(tb1qdu05evh9kw0w482lfl2ktxm6ylp060kmqpe5js)#n0s7nyz0",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_0"
+  },
+  {
+    "desc": "addr(tb1q6tjz70fyh4c3l2muk4fexfvpuq39p3657sxquy)#etka7xuj",
+    "timestamp": 1648215566,
+    "internal": false,
+    "label": "slot_2"
+  }
+]'
 
 ```
 

--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -659,7 +659,7 @@ def export_to_core(cvc, pretty, sweep_only, slot):
     )
     descriptor_list = []
     for _slot in range(card.active_slot+1):
-        if _slot not in slot:
+        if slot and _slot not in slot:
             continue
         item = deepcopy(shared)
         item["label"] = f"slot_{_slot}"

--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -14,6 +14,7 @@ from pprint import pformat
 from binascii import b2a_hex, a2b_hex
 from functools import wraps
 from getpass import getpass
+from copy import deepcopy
 
 from .utils import xor_bytes, render_address, render_wif, render_descriptor, B2A, ser_compact_size
 from .utils import make_recoverable_sig, render_sats_value, path2str, pick_nonce
@@ -630,10 +631,10 @@ def show_balance(cvc):
 @click.option('--pretty', '-p', is_flag=True, help="Pretty-print JSON")
 @click.argument('cvc', type=str, metavar="(6-digit code)", required=False)
 def export_to_core(cvc, pretty):
-    "[SC] Show JSON needed to import private keys into Bitcoin Core"
+    "[SC] Show JSON needed to import keys into Bitcoin Core"
 
     # see 
-    # - <https://bitcoincore.org/en/doc/0.21.0/rpc/wallet/importmulti/>
+    # - <https://bitcoincore.org/en/doc/0.21.0/rpc/wallet/importdescriptors/>
     # - <https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md>
     # - <https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki>
     # - <https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki>
@@ -642,46 +643,44 @@ def export_to_core(cvc, pretty):
 
     # CVC is optional, but they probably want it
     if not cvc:
-        click.echo("Warning: Without the code, can only watch addresses from this card.", err=1)
+        click.echo("Warning: Without the code, can only watch addresses from this card.\n", err=True)
     cvc = cleanup_cvc(card, cvc, missing_ok=True)
 
-    shared = dict(timestamp=PROJECT_EPOC_TIME_T, descr=[], internal=False)
-    if not cvc:
-        shared['watchonly'] = True
-
-    rv = []
+    shared = dict(
+        desc="",  # actual descriptor
+        timestamp=PROJECT_EPOC_TIME_T,
+        internal=False,
+        label=""  # label will be set to slot number
+    )
+    descriptor_list = []
     for slot in range(card.active_slot+1):
+        item = deepcopy(shared)
+        item["label"] = f"slot_{slot}"
         session_key, here = card.send_auth('dump', cvc, slot=slot)
 
-        if here.get('used', None) == False:
+        if here.get('used') is False:
             continue
 
         pk = None
         addr = None
-        if here.get('sealed', None) == True:
-            if cvc: continue
+        if here.get('sealed') is True:
             pubkey, addr = card.address(incl_pubkey=1)
 
         if 'privkey' in here:
             pk = xor_bytes(session_key, here['privkey'])
             addr = render_address(pk, card.is_testnet)
 
-        line = dict()
-        line.update(shared)
-
         if pk:
             w = render_descriptor(privkey=pk, testnet=card.is_testnet)
-        elif addr:
-            w = render_descriptor(address=addr)
-            line['pubkeys'] = [B2A(pubkey)]
         else:
-            continue
+            if addr is None:
+                addr = here["addr"]
+            w = render_descriptor(address=addr)
 
-        line['desc'] = [w]
-        rv.append(line)
+        item["desc"] = w
+        descriptor_list.append(item)
 
-    # TODO this doesn't work, but looks likely
-    click.echo('importmulti \'%s\'' % json.dumps(rv, indent=(2 if pretty else None)))
+    click.echo(f"importdescriptors '{json.dumps(descriptor_list, indent=(2 if pretty else None))}'")
 
     
 @main.command('status')

--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -629,10 +629,10 @@ def show_balance(cvc):
 
 @main.command('core')
 @click.option('--pretty', '-p', is_flag=True, help="Pretty-print JSON")
-@click.option('--sweep-only', is_flag=True, help="Only collect privkeys from unsealed slots (needs cvc)")
+@click.option('--sealed-only', '-so', is_flag=True, help="Only dump sealed slots")
 @click.option('--slot', '-s', multiple=True, type=click.IntRange(min=0, max=9))
 @click.argument('cvc', type=str, metavar="(6-digit code)", required=False)
-def export_to_core(cvc, pretty, sweep_only, slot):
+def export_to_core(cvc, pretty, slot, sealed_only):
     "[SC] Show JSON needed to import keys into Bitcoin Core"
 
     # see 
@@ -640,9 +640,6 @@ def export_to_core(cvc, pretty, sweep_only, slot):
     # - <https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md>
     # - <https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki>
     # - <https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki>
-
-    if sweep_only and cvc is None:
-        fail("CVC has to be provided for '--sweep-only'")
 
     card = get_card(only_satscard=True)
 
@@ -668,10 +665,13 @@ def export_to_core(cvc, pretty, sweep_only, slot):
         if here.get('used') is False:
             continue
 
+        if sealed_only and here.get("sealed") is not True:
+            continue
+
         pk = None
         addr = here.get("addr")
         if here.get('sealed') is True:
-            if sweep_only:
+            if cvc:
                 continue
             pubkey, addr = card.address(incl_pubkey=1)
 

--- a/cktap/descriptors.py
+++ b/cktap/descriptors.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Pieter Wuille
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Utility functions related to output descriptors"""
+
+import re
+
+INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+CHECKSUM_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+GENERATOR = [0xf5dee51989, 0xa9fdca3312, 0x1bab10e32d, 0x3706b1677a, 0x644d626ffd]
+
+def descsum_polymod(symbols):
+    """Internal function that computes the descriptor checksum."""
+    chk = 1
+    for value in symbols:
+        top = chk >> 35
+        chk = (chk & 0x7ffffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= GENERATOR[i] if ((top >> i) & 1) else 0
+    return chk
+
+def descsum_expand(s):
+    """Internal function that does the character to symbol expansion"""
+    groups = []
+    symbols = []
+    for c in s:
+        if not c in INPUT_CHARSET:
+            return None
+        v = INPUT_CHARSET.find(c)
+        symbols.append(v & 31)
+        groups.append(v >> 5)
+        if len(groups) == 3:
+            symbols.append(groups[0] * 9 + groups[1] * 3 + groups[2])
+            groups = []
+    if len(groups) == 1:
+        symbols.append(groups[0])
+    elif len(groups) == 2:
+        symbols.append(groups[0] * 3 + groups[1])
+    return symbols
+
+def descsum_create(s):
+    """Add a checksum to a descriptor without"""
+    symbols = descsum_expand(s) + [0, 0, 0, 0, 0, 0, 0, 0]
+    checksum = descsum_polymod(symbols) ^ 1
+    return s + '#' + ''.join(CHECKSUM_CHARSET[(checksum >> (5 * (7 - i))) & 31] for i in range(8))
+
+def descsum_check(s, require=True):
+    """Verify that the checksum is correct in a descriptor"""
+    if not '#' in s:
+        return not require
+    if s[-9] != '#':
+        return False
+    if not all(x in CHECKSUM_CHARSET for x in s[-8:]):
+        return False
+    symbols = descsum_expand(s[:-9]) + [CHECKSUM_CHARSET.find(x) for x in s[-8:]]
+    return descsum_polymod(symbols) == 1
+
+def drop_origins(s):
+    '''Drop the key origins from a descriptor'''
+    desc = re.sub(r'\[.+?\]', '', s)
+    if '#' in s:
+        desc = desc[:desc.index('#')]
+    return descsum_create(desc)

--- a/cktap/utils.py
+++ b/cktap/utils.py
@@ -6,6 +6,7 @@ from .constants import *
 from .compat import hash160, sha256s
 from .compat import CT_ecdh, CT_sig_verify, CT_sig_to_pubkey, CT_pick_keypair
 from .compat import CT_bip32_derive, CT_priv_to_pubkey
+from cktap.descriptors import descsum_create
 
 # show bytes as hex in a string
 B2A = lambda x: b2a_hex(x).decode('ascii')
@@ -209,16 +210,15 @@ def render_wif(privkey, bip_178=False, electrum=False, testnet=False):
 
     return ('p2wpkh:' + rv) if electrum else rv
 
-def render_descriptor(address=None, privkey=None, bip_178=False, electrum=False, testnet=False):
+def render_descriptor(address=None, privkey=None, bip_178=False, electrum=False, testnet=False, checksum=True):
     # Create a "descriptor" for Core to understand.
     assert address or privkey
     if privkey:
         rv = 'wpkh(%s)' % render_wif(privkey, testnet=testnet)
     else:
         rv = 'addr(%s)' % address
-
-    # TODO: add checksum
-
+    if checksum:
+        return descsum_create(rv)
     return rv
 
 def verify_master_pubkey(pub, sig, chain_code, my_nonce, card_nonce):

--- a/testing/test_descriptors.py
+++ b/testing/test_descriptors.py
@@ -1,0 +1,10 @@
+from cktap.descriptors import descsum_create, descsum_check
+
+def test_simple_descsum_check():
+    d1 = "addr(tb1qdu05evh9kw0w482lfl2ktxm6ylp060kmqpe5js)"
+    d2 = "wpkh(cU7CGBhwnMdLDbqBaXm3xE22KFyaA5s3YDBis88LyuPLnmfpDFFU)"
+
+    for d in [d1, d2]:
+        d_w_sum = descsum_create(d)
+        assert descsum_check(d_w_sum)
+


### PR DESCRIPTION
* add descritor checksums (`descriptors.py` stolen from bitcoin bitcoin/test/functional/descriptors.py)
* repurpose `core` cmd to use `importdescriptors` instead `importmulti` (only supported from 0.21.0)
* update README with example usage of core cmd