### PR TITLE
fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ Examples/Libraries in other languages will be added when available.
 
 ## Setup For Everyday Use
 
+First update `pip` to latest version and install wheel (otherwise legacy setup.py install will be used)
+```shell
+pip install -U pip wheel
+```
+
 Install `cktap`, our helpful command-line program, with just:
 
-    pip install 'coinkite-tap-proto[cli]'
+    pip install 'coinkite-tap-protocol[cli]'
 
 **OR**
 
-If you just want the Python library, use: `pip install coinkite-tap-proto`
+If you just want the Python library, use: `pip install coinkite-tap-protocol`
 
 
 ## Setup If You Might Change the Code


### PR DESCRIPTION
installing `coinkite-tap-proto` does not work... correct name of package is `coinkite-tap-protocol`
![Screenshot from 2022-04-05 20-55-06](https://user-images.githubusercontent.com/25349625/161833217-c7ef1747-81da-473b-88bd-01afe4c24e08.png)

Older pip versions are not good in resolving conflicts in dependencies - so it is better to update/upgrade `pip` before installing packages. First we install latest `coincurve==17.0.0` but `bip32` requires `coincurve<=17.*` so it throws ugly error to the user. With upgraded pip it solves it nicely and installs `coincurve==16.0.0`
![Screenshot from 2022-04-05 21-21-39](https://user-images.githubusercontent.com/25349625/161833767-7e4b5afa-7987-437b-b577-4a9d40a9840e.png)

