### PR TITLE
tapsgner_no_key_picked_err

### DIFF
--- a/cktap/cli.py
+++ b/cktap/cli.py
@@ -30,7 +30,7 @@ global_opts = dict()
 _sys_excepthook = sys.excepthook
 def my_hook(ty, val, tb):
     if ty in { CardRuntimeError, RuntimeError }:
-        print("\n\nFATAL: %s" % val, file=sys.stderr)
+        print("FATAL: %s" % val, file=sys.stderr)
     else:
         return _sys_excepthook(ty, val, tb)
 sys.excepthook=my_hook
@@ -453,12 +453,8 @@ def check_cvc(cvc):
 def get_path():
     "[TS] Show the subkey derivation path in effect"
     card = get_card(only_tapsigner=True)
-
     path = card.get_derivation()
-    if path == None:
-        fail("NONE (no key picked yet)")
-    else:
-        print(path)
+    print(path)
     
 @main.command('derive')
 @click.argument('path', type=str, metavar="84h/0h/0h", required=True)

--- a/cktap/proto.py
+++ b/cktap/proto.py
@@ -169,8 +169,7 @@ class CKTapCard:
         st = self.send('status')
         path = st.get('path', None)
         if path is None:
-            #raise RuntimeError("no private key picked yet, so no derivation")
-            return None
+            raise RuntimeError("No private key picked yet.")
         return path2str(path)
 
     def set_derivation(self, path, cvc):


### PR DESCRIPTION
* do raise if getting derivation and key is not yet picked up

`json` cmd spits ugly error to user if key is not picked up already
![Screenshot from 2022-04-06 05-31-25](https://user-images.githubusercontent.com/25349625/161890949-80900a00-0af3-45a8-a154-074a964a0d67.png)

when we raise in `get_derivation` all commands will have unified error message
![Screenshot from 2022-04-06 05-33-24](https://user-images.githubusercontent.com/25349625/161891078-45246004-4d12-4cbe-8c6d-105c2d9411a2.png)

