### PR TITLE
bump tor version for windows in github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,8 +87,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tor
         run: |
-          wget https://dist.torproject.org/torbrowser/11.0.10/tor-win64-0.4.6.10.zip -O tor-win64-0.4.6.10.zip
-          7z x tor-win64-0.4.6.10.zip
+          wget https://dist.torproject.org/torbrowser/11.0.14/tor-win64-0.4.7.7.zip -O tor-win64-0.4.7.7.zip
+          7z x tor-win64-0.4.7.7.zip
           cd Tor
           Start-Process "tor.exe" -WindowStyle Hidden
         shell: powershell


### PR DESCRIPTION
found issue: https://github.com/scgbckbone/coinkite-tap-proto/runs/6980421879?check_suite_focus=true

fixed by this PR 

https://github.com/scgbckbone/coinkite-tap-proto/runs/6980688067?check_suite_focus=true