### PR TITLE
Update emulator's wally dependency

### DIFF
--- a/emulator/requirements.txt
+++ b/emulator/requirements.txt
@@ -2,7 +2,7 @@
 pytest
 cbor2==5.4.1
 hexdump==3.3
-wallycore==0.8.4
+wallycore==0.8.5
 bech32==1.2.0
 pyqrcode==1.2.1
 base58==2.1.1


### PR DESCRIPTION
the old version of the package isn't available, so installing from
requirements.txt stopped working. this fixes that problem :)