### PR TITLE
bump tor version for win

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,8 +87,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tor
         run: |
-          wget https://dist.torproject.org/torbrowser/11.0.14/tor-win64-0.4.7.7.zip -O tor-win64-0.4.7.7.zip
-          7z x tor-win64-0.4.7.7.zip
+          wget https://dist.torproject.org/torbrowser/11.0.15/tor-win64-0.4.7.8.zip -O tor-win64-0.4.7.8.zip
+          7z x tor-win64-0.4.7.8.zip
           cd Tor
           Start-Process "tor.exe" -WindowStyle Hidden
         shell: powershell


### PR DESCRIPTION
* I could not find a way how to choose some kind of `latest`
* so I just bumped it again so we have green tests/actions