### PR TITLE
add HID OmniKey 5427 CK to observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ reflected in the installed version.
     - **ACS ACR1252U** - okay and widely available, and for sale by Coinkite
     - **Identiv uTrust 3700F** - reliable and looks nice
     - **HID Omnikey 5022 CL** (not 5021) - fast, cute, and small
+    - **HID OmniKey 5427 CK** - tested Gen1 device, fast, reliable, must disable keyboard wedge via EEM interface on device at `http://192.168.63.99/`, when correct will identify as VID:PID `076b:5427`
     - **NOT recommended:** ACS ACR122U. It can work, and is widely available, but is not reliable.
 - See `requirements.txt` file for python packages needed.
 


### PR DESCRIPTION
I tested a HID OmniKey 5427 CK running firmware version `0300042d` Part No: R54270001 Rev B and it worked quickly and reliably with a SATSCARD.

When the keyboard wedge interface is enabled, the CCID interface is not presented to the host, and it will identify with VID:PID `076b:5428`. This device configuration does not work with the SATSCARD.

It is easy to disable the keyboard wedge (the default when settings are reset), and enable the CCID SmartCard interface, by browsing to `http://192.168.63.99/` which is provided by the 5427's Ethernet Emulation (EEM) interface. When set correctly, the reader will identify to the host with VID:PID `076b:5427`.

Successful testing was conducted on Ubuntu 22.04.1 LTS with pcscd driver `pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so` version: 1.5.0.

The old driver from HID (December 2012), https://www3.hidglobal.com/drivers/14989, did not work with my system configuration.