### PR TITLE
Obscure padding bug in unused codepath

### DIFF
--- a/cktap/bip32.py
+++ b/cktap/bip32.py
@@ -450,7 +450,12 @@ class PrvKeyNode(PubKeyNode):
         """
         if index >= HARDENED:
             # hardened
-            data = b"\x00" + self.key + int_to_big_endian(index, 4)
+            if len(self.key) < 33:
+                to_pad = 33 - len(self.key)
+                key = (b"\x00" * to_pad) + self.key
+            else:
+                key = self.key
+            data = key + int_to_big_endian(index, 4)
         else:
             data = privkey_to_pubkey(self.key) + int_to_big_endian(index, 4)
         I = hmac.new(key=self.chain_code, msg=data, digestmod=hashlib.sha512).digest()

--- a/testing/test_bip32.py
+++ b/testing/test_bip32.py
@@ -292,3 +292,14 @@ def test_sec():
         point = decode_pubkey(pubkey, "bin_compressed")
         assert encode_pubkey(point, "bin") == bytes.fromhex(uncompressed)
         assert encode_pubkey(point, "bin_compressed") == bytes.fromhex(compressed) == pubkey
+
+
+def test_sk_33_bytes():
+    il = [2147483696, 2147483649, 2147483648, 2147483650]
+    tprv = "tprv8ZgxMBicQKsPeXJHL3vPPgTAEqQ5P2FD9qDeCQT4Cp1EMY5QkwMPWFxHdxHrxZhhcVRJ2m7BNWTz9Xre68y7mX5vCdMJ5qXMUfnrZ2si2X4"
+    m = PrvKeyNode.parse(tprv, testnet=True)
+    sk = m.get_extended_pubkey_from_path(il)
+    expected_pub = "tpubDF2rnouQaaYrXF4noGTv6rQYmx87cQ4GrUdhpvXkhtChwQPbdGTi8GA88NUaSrwZBwNsTkC9bFkkC8vDyGBVVAQTZ2AS6gs68RQXtXcCvkP"
+    expected_prv = "tprv8iLpePsASCsBdn2zucoKhSkSCvcBT4sNHB2vYQVTHcQK6v8pzse7wmYFxFzisGQ5affBk4Whg1qoQrX5jTkzQy3ENjE89KkiBWkbd9RE9Ez"
+    assert sk.extended_public_key() == expected_pub
+    assert sk.extended_private_key() == expected_prv


### PR DESCRIPTION
Found a padding bug in my implementation of BIP32. Bug would only express itself if private key is 33 bytes already. In that case I would automatically add another padding - which is wrong.

Bug severity --> None. 
We do not use extended private key parsing at all in client lib. This only affects `PrvKeyNode`. `PubKeyNode` is unaffected as there is no padding (always 33 bytes).

Only usage of `PrvKeyNode` is in `CT_bip32_derive` but then again we only allow private keys to be 32 bytes long so it cannot cause the buggy behavior. All subsequent child key derivations are unaffected as `key=int_to_big_endian(ki, 32)`.

Summary:
This bug can only be caused by `PrvKeyNode.parse(ek)` which we do not use. Our test haven't caught it as we only test with private keys of len 32. I have added a test vector with key already padded.

Good that it was found before it can cause some serious mess in the future.