### PR TITLE
(Minor) Add Fedora install note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,24 @@ reflected in the installed version.
 
 
 ## Ubuntu/Debian Notes
+
 Installing `pyscard` require SWIG and libpcsclite:
+
 ```shell
 # run below before installing dependencies with pip
 # tested on Ubuntu 20.04 (only)
 sudo apt-get install swig
 sudo apt-get install libpcsclite-dev
+```
+
+## Fedora/Red Hat Notes
+
+Installing `pyscard` requires SWIG and the pcsc-lite library:
+
+```shell
+# run below before installing dependencies with pip
+# tested on Fedora 37 (only)
+sudo dnf install swig pcsc-lite-devel
 ```
 
 ## Windows Notes


### PR DESCRIPTION
Package name for the PCSC library is different on Fedora & friends, so adding a note to avoid needing to do some searching, as otherwise cktap seems to work fine